### PR TITLE
Atkbd improvements

### DIFF
--- a/drivers/input/keyboard/atkbd.c
+++ b/drivers/input/keyboard/atkbd.c
@@ -5,7 +5,6 @@
  * Copyright (c) 1999-2002 Vojtech Pavlik
  */
 
-
 /*
  * This driver can handle standard AT keyboards and PS/2 keyboards in
  * Translated and Raw Set 2 and Set 3, as well as AT keyboards on dumb
@@ -27,7 +26,7 @@
 #include <linux/dmi.h>
 #include <linux/property.h>
 
-#define DRIVER_DESC	"AT and PS/2 keyboard driver"
+#define DRIVER_DESC "AT and PS/2 keyboard driver"
 
 MODULE_AUTHOR("Vojtech Pavlik <vojtech@suse.cz>");
 MODULE_DESCRIPTION(DRIVER_DESC);
@@ -35,7 +34,8 @@ MODULE_LICENSE("GPL");
 
 static int atkbd_set = 2;
 module_param_named(set, atkbd_set, int, 0);
-MODULE_PARM_DESC(set, "Select keyboard code set (2 = default, 3 = PS/2 native)");
+MODULE_PARM_DESC(set,
+		 "Select keyboard code set (2 = default, 3 = PS/2 native)");
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__hppa__)
 static bool atkbd_reset;
@@ -55,25 +55,30 @@ MODULE_PARM_DESC(softraw, "Use software generated rawmode");
 
 static bool atkbd_scroll;
 module_param_named(scroll, atkbd_scroll, bool, 0);
-MODULE_PARM_DESC(scroll, "Enable scroll-wheel on MS Office and similar keyboards");
+MODULE_PARM_DESC(scroll,
+		 "Enable scroll-wheel on MS Office and similar keyboards");
 
 static bool atkbd_extra;
 module_param_named(extra, atkbd_extra, bool, 0);
-MODULE_PARM_DESC(extra, "Enable extra LEDs and keys on IBM RapidAcces, EzKey and similar keyboards");
+MODULE_PARM_DESC(
+	extra,
+	"Enable extra LEDs and keys on IBM RapidAcces, EzKey and similar keyboards");
 
 static bool atkbd_terminal;
 module_param_named(terminal, atkbd_terminal, bool, 0);
-MODULE_PARM_DESC(terminal, "Enable break codes on an IBM Terminal keyboard connected via AT/PS2");
+MODULE_PARM_DESC(
+	terminal,
+	"Enable break codes on an IBM Terminal keyboard connected via AT/PS2");
 
-#define SCANCODE(keymap)	((keymap >> 16) & 0xFFFF)
-#define KEYCODE(keymap)		(keymap & 0xFFFF)
+#define SCANCODE(keymap) ((keymap >> 16) & 0xFFFF)
+#define KEYCODE(keymap) (keymap & 0xFFFF)
 
 /*
  * Scancode to keycode tables. These are just the default setting, and
  * are loadable via a userland utility.
  */
 
-#define ATKBD_KEYMAP_SIZE	512
+#define ATKBD_KEYMAP_SIZE 512
 
 static const unsigned short atkbd_set2_keycode[ATKBD_KEYMAP_SIZE] = {
 
@@ -81,117 +86,122 @@ static const unsigned short atkbd_set2_keycode[ATKBD_KEYMAP_SIZE] = {
 
 /* XXX: need a more general approach */
 
-#include "hpps2atkbd.h"	/* include the keyboard scancodes */
+#include "hpps2atkbd.h" /* include the keyboard scancodes */
 
 #else
-	  0, 67, 65, 63, 61, 59, 60, 88,  0, 68, 66, 64, 62, 15, 41,117,
-	  0, 56, 42, 93, 29, 16,  2,  0,  0,  0, 44, 31, 30, 17,  3,  0,
-	  0, 46, 45, 32, 18,  5,  4, 95,  0, 57, 47, 33, 20, 19,  6,183,
-	  0, 49, 48, 35, 34, 21,  7,184,  0,  0, 50, 36, 22,  8,  9,185,
-	  0, 51, 37, 23, 24, 11, 10,  0,  0, 52, 53, 38, 39, 25, 12,  0,
-	  0, 89, 40,  0, 26, 13,  0,  0, 58, 54, 28, 27,  0, 43,  0, 85,
-	  0, 86, 91, 90, 92,  0, 14, 94,  0, 79,124, 75, 71,121,  0,  0,
-	 82, 83, 80, 76, 77, 72,  1, 69, 87, 78, 81, 74, 55, 73, 70, 99,
+	0,   67,  65,  63,  61,	 59,  60,  88,	0,   68,  66,  64,  62,
+	15,  41,  117, 0,   56,	 42,  93,  29,	16,  2,	  0,   0,   0,
+	44,  31,  30,  17,  3,	 0,   0,   46,	45,  32,  18,  5,   4,
+	95,  0,	  57,  47,  33,	 20,  19,  6,	183, 0,	  49,  48,  35,
+	34,  21,  7,   184, 0,	 0,   50,  36,	22,  8,	  9,   185, 0,
+	51,  37,  23,  24,  11,	 10,  0,   0,	52,  53,  38,  39,  25,
+	12,  0,	  0,   89,  40,	 0,   26,  13,	0,   0,	  58,  54,  28,
+	27,  0,	  43,  0,   85,	 0,   86,  91,	90,  92,  0,   14,  94,
+	0,   79,  124, 75,  71,	 121, 0,   0,	82,  83,  80,  76,  77,
+	72,  1,	  69,  87,  78,	 81,  74,  55,	73,  70,  99,
 
-	  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
-	217,100,255,  0, 97,165,  0,  0,156,  0,  0,  0,  0,  0,  0,125,
-	173,114,  0,113,  0,  0,  0,126,128,  0,  0,140,  0,  0,  0,127,
-	159,  0,115,  0,164,  0,  0,116,158,  0,172,166,  0,  0,  0,142,
-	157,  0,  0,  0,  0,  0,  0,  0,155,  0, 98,  0,  0,163,  0,  0,
-	226,  0,  0,  0,  0,  0,  0,  0,  0,255, 96,  0,  0,  0,143,  0,
-	  0,  0,  0,  0,  0,  0,  0,  0,  0,107,  0,105,102,  0,  0,112,
-	110,111,108,112,106,103,  0,119,  0,118,109,  0, 99,104,119,  0,
+	0,   0,	  0,   0,   0,	 0,   0,   0,	0,   0,	  0,   0,   0,
+	0,   0,	  0,   217, 100, 255, 0,   97,	165, 0,	  0,   156, 0,
+	0,   0,	  0,   0,   0,	 125, 173, 114, 0,   113, 0,   0,   0,
+	126, 128, 0,   0,   140, 0,   0,   0,	127, 159, 0,   115, 0,
+	164, 0,	  0,   116, 158, 0,   172, 166, 0,   0,	  0,   142, 157,
+	0,   0,	  0,   0,   0,	 0,   0,   155, 0,   98,  0,   0,   163,
+	0,   0,	  226, 0,   0,	 0,   0,   0,	0,   0,	  0,   255, 96,
+	0,   0,	  0,   143, 0,	 0,   0,   0,	0,   0,	  0,   0,   0,
+	0,   107, 0,   105, 102, 0,   0,   112, 110, 111, 108, 112, 106,
+	103, 0,	  119, 0,   118, 109, 0,   99,	104, 119, 0,
 
-	  0,  0,  0, 65, 99,
+	0,   0,	  0,   65,  99,
 #endif
 };
 
 static const unsigned short atkbd_set3_keycode[ATKBD_KEYMAP_SIZE] = {
 
-	  0,  0,  0,  0,  0,  0,  0, 59,  1,138,128,129,130, 15, 41, 60,
-	131, 29, 42, 86, 58, 16,  2, 61,133, 56, 44, 31, 30, 17,  3, 62,
-	134, 46, 45, 32, 18,  5,  4, 63,135, 57, 47, 33, 20, 19,  6, 64,
-	136, 49, 48, 35, 34, 21,  7, 65,137,100, 50, 36, 22,  8,  9, 66,
-	125, 51, 37, 23, 24, 11, 10, 67,126, 52, 53, 38, 39, 25, 12, 68,
-	113,114, 40, 43, 26, 13, 87, 99, 97, 54, 28, 27, 43, 43, 88, 70,
-	108,105,119,103,111,107, 14,110,  0, 79,106, 75, 71,109,102,104,
-	 82, 83, 80, 76, 77, 72, 69, 98,  0, 96, 81,  0, 78, 73, 55,183,
+	0,   0,	  0,   0,   0,	 0,   0,   59,	1,   138, 128, 129, 130,
+	15,  41,  60,  131, 29,	 42,  86,  58,	16,  2,	  61,  133, 56,
+	44,  31,  30,  17,  3,	 62,  134, 46,	45,  32,  18,  5,   4,
+	63,  135, 57,  47,  33,	 20,  19,  6,	64,  136, 49,  48,  35,
+	34,  21,  7,   65,  137, 100, 50,  36,	22,  8,	  9,   66,  125,
+	51,  37,  23,  24,  11,	 10,  67,  126, 52,  53,  38,  39,  25,
+	12,  68,  113, 114, 40,	 43,  26,  13,	87,  99,  97,  54,  28,
+	27,  43,  43,  88,  70,	 108, 105, 119, 103, 111, 107, 14,  110,
+	0,   79,  106, 75,  71,	 109, 102, 104, 82,  83,  80,  76,  77,
+	72,  69,  98,  0,   96,	 81,  0,   78,	73,  55,  183,
 
-	184,185,186,187, 74, 94, 92, 93,  0,  0,  0,125,126,127,112,  0,
-	  0,139,172,163,165,115,152,172,166,140,160,154,113,114,167,168,
-	148,149,147,140
+	184, 185, 186, 187, 74,	 94,  92,  93,	0,   0,	  0,   125, 126,
+	127, 112, 0,   0,   139, 172, 163, 165, 115, 152, 172, 166, 140,
+	160, 154, 113, 114, 167, 168, 148, 149, 147, 140
 };
 
 static const unsigned short atkbd_unxlate_table[128] = {
-          0,118, 22, 30, 38, 37, 46, 54, 61, 62, 70, 69, 78, 85,102, 13,
-         21, 29, 36, 45, 44, 53, 60, 67, 68, 77, 84, 91, 90, 20, 28, 27,
-         35, 43, 52, 51, 59, 66, 75, 76, 82, 14, 18, 93, 26, 34, 33, 42,
-         50, 49, 58, 65, 73, 74, 89,124, 17, 41, 88,  5,  6,  4, 12,  3,
-         11,  2, 10,  1,  9,119,126,108,117,125,123,107,115,116,121,105,
-        114,122,112,113,127, 96, 97,120,  7, 15, 23, 31, 39, 47, 55, 63,
-         71, 79, 86, 94,  8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 87,111,
-         19, 25, 57, 81, 83, 92, 95, 98, 99,100,101,103,104,106,109,110
+	0,   118, 22,  30,  38,	 37,  46,  54,	61,  62,  70,  69,  78,
+	85,  102, 13,  21,  29,	 36,  45,  44,	53,  60,  67,  68,  77,
+	84,  91,  90,  20,  28,	 27,  35,  43,	52,  51,  59,  66,  75,
+	76,  82,  14,  18,  93,	 26,  34,  33,	42,  50,  49,  58,  65,
+	73,  74,  89,  124, 17,	 41,  88,  5,	6,   4,	  12,  3,   11,
+	2,   10,  1,   9,   119, 126, 108, 117, 125, 123, 107, 115, 116,
+	121, 105, 114, 122, 112, 113, 127, 96,	97,  120, 7,   15,  23,
+	31,  39,  47,  55,  63,	 71,  79,  86,	94,  8,	  16,  24,  32,
+	40,  48,  56,  64,  72,	 80,  87,  111, 19,  25,  57,  81,  83,
+	92,  95,  98,  99,  100, 101, 103, 104, 106, 109, 110
 };
 
-#define ATKBD_CMD_SETLEDS	0x10ed
-#define ATKBD_CMD_GSCANSET	0x11f0
-#define ATKBD_CMD_SSCANSET	0x10f0
-#define ATKBD_CMD_GETID		0x02f2
-#define ATKBD_CMD_SETREP	0x10f3
-#define ATKBD_CMD_ENABLE	0x00f4
-#define ATKBD_CMD_RESET_DIS	0x00f5	/* Reset to defaults and disable */
-#define ATKBD_CMD_RESET_DEF	0x00f6	/* Reset to defaults */
-#define ATKBD_CMD_SETALL_MB	0x00f8	/* Set all keys to give break codes */
-#define ATKBD_CMD_SETALL_MBR	0x00fa  /* ... and repeat */
-#define ATKBD_CMD_RESET_BAT	0x02ff
-#define ATKBD_CMD_RESEND	0x00fe
-#define ATKBD_CMD_EX_ENABLE	0x10ea
-#define ATKBD_CMD_EX_SETLEDS	0x20eb
-#define ATKBD_CMD_OK_GETID	0x02e8
+#define ATKBD_CMD_SETLEDS 0x10ed
+#define ATKBD_CMD_GSCANSET 0x11f0
+#define ATKBD_CMD_SSCANSET 0x10f0
+#define ATKBD_CMD_GETID 0x02f2
+#define ATKBD_CMD_SETREP 0x10f3
+#define ATKBD_CMD_ENABLE 0x00f4
+#define ATKBD_CMD_RESET_DIS 0x00f5 /* Reset to defaults and disable */
+#define ATKBD_CMD_RESET_DEF 0x00f6 /* Reset to defaults */
+#define ATKBD_CMD_SETALL_MB 0x00f8 /* Set all keys to give break codes */
+#define ATKBD_CMD_SETALL_MBR 0x00fa /* ... and repeat */
+#define ATKBD_CMD_RESET_BAT 0x02ff
+#define ATKBD_CMD_RESEND 0x00fe
+#define ATKBD_CMD_EX_ENABLE 0x10ea
+#define ATKBD_CMD_EX_SETLEDS 0x20eb
+#define ATKBD_CMD_OK_GETID 0x02e8
 
-#define ATKBD_RET_ACK		0xfa
-#define ATKBD_RET_NAK		0xfe
-#define ATKBD_RET_BAT		0xaa
-#define ATKBD_RET_EMUL0		0xe0
-#define ATKBD_RET_EMUL1		0xe1
-#define ATKBD_RET_RELEASE	0xf0
-#define ATKBD_RET_HANJA		0xf1
-#define ATKBD_RET_HANGEUL	0xf2
-#define ATKBD_RET_ERR		0xff
+#define ATKBD_RET_ACK 0xfa
+#define ATKBD_RET_NAK 0xfe
+#define ATKBD_RET_BAT 0xaa
+#define ATKBD_RET_EMUL0 0xe0
+#define ATKBD_RET_EMUL1 0xe1
+#define ATKBD_RET_RELEASE 0xf0
+#define ATKBD_RET_HANJA 0xf1
+#define ATKBD_RET_HANGEUL 0xf2
+#define ATKBD_RET_ERR 0xff
 
-#define ATKBD_KEY_UNKNOWN	0
-#define ATKBD_KEY_NULL		255
+#define ATKBD_KEY_UNKNOWN 0
+#define ATKBD_KEY_NULL 255
 
-#define ATKBD_SCR_1		0xfffe
-#define ATKBD_SCR_2		0xfffd
-#define ATKBD_SCR_4		0xfffc
-#define ATKBD_SCR_8		0xfffb
-#define ATKBD_SCR_CLICK		0xfffa
-#define ATKBD_SCR_LEFT		0xfff9
-#define ATKBD_SCR_RIGHT		0xfff8
+#define ATKBD_SCR_1 0xfffe
+#define ATKBD_SCR_2 0xfffd
+#define ATKBD_SCR_4 0xfffc
+#define ATKBD_SCR_8 0xfffb
+#define ATKBD_SCR_CLICK 0xfffa
+#define ATKBD_SCR_LEFT 0xfff9
+#define ATKBD_SCR_RIGHT 0xfff8
 
-#define ATKBD_SPECIAL		ATKBD_SCR_RIGHT
+#define ATKBD_SPECIAL ATKBD_SCR_RIGHT
 
-#define ATKBD_LED_EVENT_BIT	0
-#define ATKBD_REP_EVENT_BIT	1
+#define ATKBD_LED_EVENT_BIT 0
+#define ATKBD_REP_EVENT_BIT 1
 
-#define ATKBD_XL_ERR		0x01
-#define ATKBD_XL_BAT		0x02
-#define ATKBD_XL_ACK		0x04
-#define ATKBD_XL_NAK		0x08
-#define ATKBD_XL_HANGEUL	0x10
-#define ATKBD_XL_HANJA		0x20
+#define ATKBD_XL_ERR 0x01
+#define ATKBD_XL_BAT 0x02
+#define ATKBD_XL_ACK 0x04
+#define ATKBD_XL_NAK 0x08
+#define ATKBD_XL_HANGEUL 0x10
+#define ATKBD_XL_HANJA 0x20
 
 static const struct {
 	unsigned short keycode;
 	unsigned char set2;
 } atkbd_scroll_keys[] = {
-	{ ATKBD_SCR_1,     0xc5 },
-	{ ATKBD_SCR_2,     0x9d },
-	{ ATKBD_SCR_4,     0xa4 },
-	{ ATKBD_SCR_8,     0x9b },
-	{ ATKBD_SCR_CLICK, 0xe0 },
-	{ ATKBD_SCR_LEFT,  0xcb },
+	{ ATKBD_SCR_1, 0xc5 },	   { ATKBD_SCR_2, 0x9d },
+	{ ATKBD_SCR_4, 0xa4 },	   { ATKBD_SCR_8, 0x9b },
+	{ ATKBD_SCR_CLICK, 0xe0 }, { ATKBD_SCR_LEFT, 0xcb },
 	{ ATKBD_SCR_RIGHT, 0xd2 },
 };
 
@@ -200,7 +210,6 @@ static const struct {
  */
 
 struct atkbd {
-
 	struct ps2dev ps2dev;
 	struct input_dev *dev;
 
@@ -244,7 +253,8 @@ struct atkbd {
  */
 static void (*atkbd_platform_fixup)(struct atkbd *, const void *data);
 static void *atkbd_platform_fixup_data;
-static unsigned int (*atkbd_platform_scancode_fixup)(struct atkbd *, unsigned int);
+static unsigned int (*atkbd_platform_scancode_fixup)(struct atkbd *,
+						     unsigned int);
 
 /*
  * Certain keyboards to not like ATKBD_CMD_RESET_DIS and stop responding
@@ -253,24 +263,29 @@ static unsigned int (*atkbd_platform_scancode_fixup)(struct atkbd *, unsigned in
 static bool atkbd_skip_deactivate;
 
 static ssize_t atkbd_attr_show_helper(struct device *dev, char *buf,
-				ssize_t (*handler)(struct atkbd *, char *));
-static ssize_t atkbd_attr_set_helper(struct device *dev, const char *buf, size_t count,
-				ssize_t (*handler)(struct atkbd *, const char *, size_t));
-#define ATKBD_DEFINE_ATTR(_name)						\
-static ssize_t atkbd_show_##_name(struct atkbd *, char *);			\
-static ssize_t atkbd_set_##_name(struct atkbd *, const char *, size_t);		\
-static ssize_t atkbd_do_show_##_name(struct device *d,				\
-				struct device_attribute *attr, char *b)		\
-{										\
-	return atkbd_attr_show_helper(d, b, atkbd_show_##_name);		\
-}										\
-static ssize_t atkbd_do_set_##_name(struct device *d,				\
-			struct device_attribute *attr, const char *b, size_t s)	\
-{										\
-	return atkbd_attr_set_helper(d, b, s, atkbd_set_##_name);		\
-}										\
-static struct device_attribute atkbd_attr_##_name =				\
-	__ATTR(_name, S_IWUSR | S_IRUGO, atkbd_do_show_##_name, atkbd_do_set_##_name);
+				      ssize_t (*handler)(struct atkbd *,
+							 char *));
+static ssize_t
+atkbd_attr_set_helper(struct device *dev, const char *buf, size_t count,
+		      ssize_t (*handler)(struct atkbd *, const char *, size_t));
+#define ATKBD_DEFINE_ATTR(_name)                                           \
+	static ssize_t atkbd_show_##_name(struct atkbd *, char *);         \
+	static ssize_t atkbd_set_##_name(struct atkbd *, const char *,     \
+					 size_t);                          \
+	static ssize_t atkbd_do_show_##_name(                              \
+		struct device *d, struct device_attribute *attr, char *b)  \
+	{                                                                  \
+		return atkbd_attr_show_helper(d, b, atkbd_show_##_name);   \
+	}                                                                  \
+	static ssize_t atkbd_do_set_##_name(struct device *d,              \
+					    struct device_attribute *attr, \
+					    const char *b, size_t s)       \
+	{                                                                  \
+		return atkbd_attr_set_helper(d, b, s, atkbd_set_##_name);  \
+	}                                                                  \
+	static struct device_attribute atkbd_attr_##_name =                \
+		__ATTR(_name, S_IWUSR | S_IRUGO, atkbd_do_show_##_name,    \
+		       atkbd_do_set_##_name);
 
 ATKBD_DEFINE_ATTR(extra);
 ATKBD_DEFINE_ATTR(force_release);
@@ -279,15 +294,15 @@ ATKBD_DEFINE_ATTR(set);
 ATKBD_DEFINE_ATTR(softrepeat);
 ATKBD_DEFINE_ATTR(softraw);
 
-#define ATKBD_DEFINE_RO_ATTR(_name)						\
-static ssize_t atkbd_show_##_name(struct atkbd *, char *);			\
-static ssize_t atkbd_do_show_##_name(struct device *d,				\
-				struct device_attribute *attr, char *b)		\
-{										\
-	return atkbd_attr_show_helper(d, b, atkbd_show_##_name);		\
-}										\
-static struct device_attribute atkbd_attr_##_name =				\
-	__ATTR(_name, S_IRUGO, atkbd_do_show_##_name, NULL);
+#define ATKBD_DEFINE_RO_ATTR(_name)                                       \
+	static ssize_t atkbd_show_##_name(struct atkbd *, char *);        \
+	static ssize_t atkbd_do_show_##_name(                             \
+		struct device *d, struct device_attribute *attr, char *b) \
+	{                                                                 \
+		return atkbd_attr_show_helper(d, b, atkbd_show_##_name);  \
+	}                                                                 \
+	static struct device_attribute atkbd_attr_##_name =               \
+		__ATTR(_name, S_IRUGO, atkbd_do_show_##_name, NULL);
 
 ATKBD_DEFINE_RO_ATTR(err_count);
 ATKBD_DEFINE_RO_ATTR(function_row_physmap);
@@ -310,7 +325,7 @@ static ssize_t atkbd_show_function_row_physmap(struct atkbd *atkbd, char *buf)
 }
 
 static umode_t atkbd_attr_is_visible(struct kobject *kobj,
-				struct attribute *attr, int i)
+				     struct attribute *attr, int i)
 {
 	struct device *dev = kobj_to_dev(kobj);
 	struct serio *serio = to_serio_port(dev);
@@ -324,14 +339,14 @@ static umode_t atkbd_attr_is_visible(struct kobject *kobj,
 }
 
 static const struct attribute_group atkbd_attribute_group = {
-	.attrs	= atkbd_attributes,
+	.attrs = atkbd_attributes,
 	.is_visible = atkbd_attr_is_visible,
 };
 
 __ATTRIBUTE_GROUPS(atkbd_attribute);
 
 static const unsigned int xl_table[] = {
-	ATKBD_RET_BAT, ATKBD_RET_ERR, ATKBD_RET_ACK,
+	ATKBD_RET_BAT, ATKBD_RET_ERR,	ATKBD_RET_ACK,
 	ATKBD_RET_NAK, ATKBD_RET_HANJA, ATKBD_RET_HANGEUL,
 };
 
@@ -377,12 +392,13 @@ static void atkbd_calculate_xl_bit(struct atkbd *atkbd, unsigned char code)
  * Encode the scancode, 0xe0 prefix, and high bit into a single integer,
  * keeping kernel 2.4 compatibility for set 2
  */
-static unsigned int atkbd_compat_scancode(struct atkbd *atkbd, unsigned int code)
+static unsigned int atkbd_compat_scancode(struct atkbd *atkbd,
+					  unsigned int code)
 {
 	if (atkbd->set == 3) {
 		if (atkbd->emul == 1)
 			code |= 0x100;
-        } else {
+	} else {
 		code = (code & 0x7f) | ((code & 0x80) << 1);
 		if (atkbd->emul == 1)
 			code |= 0x80;
@@ -408,8 +424,9 @@ static irqreturn_t atkbd_interrupt(struct serio *serio, unsigned char data,
 
 	dev_dbg(&serio->dev, "Received %02x flags %02x\n", data, flags);
 
-#if !defined(__i386__) && !defined (__x86_64__)
-	if ((flags & (SERIO_FRAME | SERIO_PARITY)) && (~flags & SERIO_TIMEOUT) && !atkbd->resend && atkbd->write) {
+#if !defined(__i386__) && !defined(__x86_64__)
+	if ((flags & (SERIO_FRAME | SERIO_PARITY)) &&
+	    (~flags & SERIO_TIMEOUT) && !atkbd->resend && atkbd->write) {
 		dev_warn(&serio->dev, "Frame/parity error: %02x\n", flags);
 		serio_write(serio, ATKBD_CMD_RESEND);
 		atkbd->resend = true;
@@ -421,11 +438,11 @@ static irqreturn_t atkbd_interrupt(struct serio *serio, unsigned char data,
 #endif
 
 	if (unlikely(atkbd->ps2dev.flags & PS2_FLAG_ACK))
-		if  (ps2_handle_ack(&atkbd->ps2dev, data))
+		if (ps2_handle_ack(&atkbd->ps2dev, data))
 			goto out;
 
 	if (unlikely(atkbd->ps2dev.flags & PS2_FLAG_CMD))
-		if  (ps2_handle_response(&atkbd->ps2dev, data))
+		if (ps2_handle_response(&atkbd->ps2dev, data))
 			goto out;
 
 	pm_wakeup_event(&serio->dev, 0);
@@ -439,7 +456,6 @@ static irqreturn_t atkbd_interrupt(struct serio *serio, unsigned char data,
 		code = atkbd_platform_scancode_fixup(atkbd, code);
 
 	if (atkbd->translated) {
-
 		if (atkbd->emul || atkbd_need_xlate(atkbd->xl_bit, code)) {
 			atkbd->release = code >> 7;
 			code &= 0x7f;
@@ -466,14 +482,17 @@ static irqreturn_t atkbd_interrupt(struct serio *serio, unsigned char data,
 	case ATKBD_RET_ACK:
 	case ATKBD_RET_NAK:
 		if (printk_ratelimit())
-			dev_warn(&serio->dev,
-				 "Spurious %s on %s. "
-				 "Some program might be trying to access hardware directly.\n",
-				 data == ATKBD_RET_ACK ? "ACK" : "NAK", serio->phys);
+			dev_warn(
+				&serio->dev,
+				"Spurious %s on %s. "
+				"Some program might be trying to access hardware directly.\n",
+				data == ATKBD_RET_ACK ? "ACK" : "NAK",
+				serio->phys);
 		goto out;
 	case ATKBD_RET_ERR:
 		atkbd->err_count++;
-		dev_dbg(&serio->dev, "Keyboard on %s reports too many keys pressed.\n",
+		dev_dbg(&serio->dev,
+			"Keyboard on %s reports too many keys pressed.\n",
 			serio->phys);
 		goto out;
 	}
@@ -496,11 +515,12 @@ static irqreturn_t atkbd_interrupt(struct serio *serio, unsigned char data,
 		dev_warn(&serio->dev,
 			 "Unknown key %s (%s set %d, code %#x on %s).\n",
 			 atkbd->release ? "released" : "pressed",
-			 atkbd->translated ? "translated" : "raw",
-			 atkbd->set, code, serio->phys);
-		dev_warn(&serio->dev,
-			 "Use 'setkeycodes %s%02x <keycode>' to make it known.\n",
-			 code & 0x80 ? "e0" : "", code & 0x7f);
+			 atkbd->translated ? "translated" : "raw", atkbd->set,
+			 code, serio->phys);
+		dev_warn(
+			&serio->dev,
+			"Use 'setkeycodes %s%02x <keycode>' to make it known.\n",
+			code & 0x80 ? "e0" : "", code & 0x7f);
 		input_sync(dev);
 		break;
 	case ATKBD_SCR_1:
@@ -530,11 +550,15 @@ static irqreturn_t atkbd_interrupt(struct serio *serio, unsigned char data,
 			atkbd->last = 0;
 		} else if (!atkbd->softrepeat && test_bit(keycode, dev->key)) {
 			/* Workaround Toshiba laptop multiple keypress */
-			value = time_before(jiffies, atkbd->time) && atkbd->last == code ? 1 : 2;
+			value = time_before(jiffies, atkbd->time) &&
+						atkbd->last == code ?
+					1 :
+					2;
 		} else {
 			value = 1;
 			atkbd->last = code;
-			atkbd->time = jiffies + msecs_to_jiffies(dev->rep[REP_DELAY]) / 2;
+			atkbd->time = jiffies +
+				      msecs_to_jiffies(dev->rep[REP_DELAY]) / 2;
 		}
 
 		input_event(dev, EV_KEY, keycode, value);
@@ -563,11 +587,11 @@ out:
 
 static int atkbd_set_repeat_rate(struct atkbd *atkbd)
 {
-	const short period[32] =
-		{ 33,  37,  42,  46,  50,  54,  58,  63,  67,  75,  83,  92, 100, 109, 116, 125,
-		 133, 149, 167, 182, 200, 217, 232, 250, 270, 303, 333, 370, 400, 435, 470, 500 };
-	const short delay[4] =
-		{ 250, 500, 750, 1000 };
+	const short period[32] = { 33,	37,  42,  46,  50,  54,	 58,  63,
+				   67,	75,  83,  92,  100, 109, 116, 125,
+				   133, 149, 167, 182, 200, 217, 232, 250,
+				   270, 303, 333, 370, 400, 435, 470, 500 };
+	const short delay[4] = { 250, 500, 750, 1000 };
 
 	struct input_dev *dev = atkbd->dev;
 	unsigned char param;
@@ -590,19 +614,19 @@ static int atkbd_set_leds(struct atkbd *atkbd)
 	struct input_dev *dev = atkbd->dev;
 	unsigned char param[2];
 
-	param[0] = (test_bit(LED_SCROLLL, dev->led) ? 1 : 0)
-		 | (test_bit(LED_NUML,    dev->led) ? 2 : 0)
-		 | (test_bit(LED_CAPSL,   dev->led) ? 4 : 0);
+	param[0] = (test_bit(LED_SCROLLL, dev->led) ? 1 : 0) |
+		   (test_bit(LED_NUML, dev->led) ? 2 : 0) |
+		   (test_bit(LED_CAPSL, dev->led) ? 4 : 0);
 	if (ps2_command(&atkbd->ps2dev, param, ATKBD_CMD_SETLEDS))
 		return -1;
 
 	if (atkbd->extra) {
 		param[0] = 0;
-		param[1] = (test_bit(LED_COMPOSE, dev->led) ? 0x01 : 0)
-			 | (test_bit(LED_SLEEP,   dev->led) ? 0x02 : 0)
-			 | (test_bit(LED_SUSPEND, dev->led) ? 0x04 : 0)
-			 | (test_bit(LED_MISC,    dev->led) ? 0x10 : 0)
-			 | (test_bit(LED_MUTE,    dev->led) ? 0x20 : 0);
+		param[1] = (test_bit(LED_COMPOSE, dev->led) ? 0x01 : 0) |
+			   (test_bit(LED_SLEEP, dev->led) ? 0x02 : 0) |
+			   (test_bit(LED_SUSPEND, dev->led) ? 0x04 : 0) |
+			   (test_bit(LED_MISC, dev->led) ? 0x10 : 0) |
+			   (test_bit(LED_MUTE, dev->led) ? 0x20 : 0);
 		if (ps2_command(&atkbd->ps2dev, param, ATKBD_CMD_EX_SETLEDS))
 			return -1;
 	}
@@ -630,7 +654,7 @@ static void atkbd_event_work(struct work_struct *work)
 		 * rescheduling till reconnect completes.
 		 */
 		schedule_delayed_work(&atkbd->event_work,
-					msecs_to_jiffies(100));
+				      msecs_to_jiffies(100));
 	} else {
 		if (test_and_clear_bit(ATKBD_LED_EVENT_BIT, &atkbd->event_mask))
 			atkbd_set_leds(atkbd);
@@ -665,8 +689,8 @@ static void atkbd_schedule_event_work(struct atkbd *atkbd, int event_bit)
  * interrupt context it is offloaded to atkbd_event_work.
  */
 
-static int atkbd_event(struct input_dev *dev,
-			unsigned int type, unsigned int code, int value)
+static int atkbd_event(struct input_dev *dev, unsigned int type,
+		       unsigned int code, int value)
 {
 	struct atkbd *atkbd = input_get_drvdata(dev);
 
@@ -674,7 +698,6 @@ static int atkbd_event(struct input_dev *dev,
 		return -1;
 
 	switch (type) {
-
 	case EV_LED:
 		atkbd_schedule_event_work(atkbd, ATKBD_LED_EVENT_BIT);
 		return 0;
@@ -717,7 +740,7 @@ static int atkbd_activate(struct atkbd *atkbd)
 {
 	struct ps2dev *ps2dev = &atkbd->ps2dev;
 
-/*
+	/*
  * Enable the keyboard to receive keystrokes.
  */
 
@@ -755,7 +778,7 @@ static int atkbd_probe(struct atkbd *atkbd)
 	struct ps2dev *ps2dev = &atkbd->ps2dev;
 	unsigned char param[2];
 
-/*
+	/*
  * Some systems, where the bit-twiddling when testing the io-lines of the
  * controller may confuse the keyboard need a full reset of the keyboard. On
  * these systems the BIOS also usually doesn't do it for us.
@@ -767,17 +790,16 @@ static int atkbd_probe(struct atkbd *atkbd)
 				 "keyboard reset failed on %s\n",
 				 ps2dev->serio->phys);
 
-/*
+	/*
  * Then we check the keyboard ID. We should get 0xab83 under normal conditions.
  * Some keyboards report different values, but the first byte is always 0xab or
  * 0xac. Some old AT keyboards don't report anything. If a mouse is connected, this
  * should make sure we don't try to set the LEDs on it.
  */
 
-	param[0] = param[1] = 0xa5;	/* initialize with invalid values */
+	param[0] = param[1] = 0xa5; /* initialize with invalid values */
 	if (ps2_command(ps2dev, param, ATKBD_CMD_GETID)) {
-
-/*
+		/*
  * If the get ID command failed, we check if we can at least set the LEDs on
  * the keyboard. This should work on every keyboard out there. It also turns
  * the LEDs off, which we want anyway.
@@ -801,7 +823,7 @@ static int atkbd_probe(struct atkbd *atkbd)
 		return -1;
 	}
 
-/*
+	/*
  * Make sure nothing is coming from the keyboard and disturbs our
  * internal state.
  */
@@ -817,13 +839,14 @@ static int atkbd_probe(struct atkbd *atkbd)
  * to Set 3, but don't work well in that (BTC Multimedia ...)
  */
 
-static int atkbd_select_set(struct atkbd *atkbd, int target_set, int allow_extra)
+static int atkbd_select_set(struct atkbd *atkbd, int target_set,
+			    int allow_extra)
 {
 	struct ps2dev *ps2dev = &atkbd->ps2dev;
 	unsigned char param[2];
 
 	atkbd->extra = false;
-/*
+	/*
  * For known special keyboards we can go ahead and set the correct set.
  * We check for NCD PS/2 Sun, NorthGate OmniKey 101 and
  * IBM RapidAccess / IBM EzButton / Chicony KBP-8993 keyboards.
@@ -880,10 +903,10 @@ static int atkbd_select_set(struct atkbd *atkbd, int target_set, int allow_extra
 
 static int atkbd_reset_state(struct atkbd *atkbd)
 {
-        struct ps2dev *ps2dev = &atkbd->ps2dev;
+	struct ps2dev *ps2dev = &atkbd->ps2dev;
 	unsigned char param[1];
 
-/*
+	/*
  * Set the LEDs to a predefined state (all off).
  */
 
@@ -891,7 +914,7 @@ static int atkbd_reset_state(struct atkbd *atkbd)
 	if (ps2_command(ps2dev, param, ATKBD_CMD_SETLEDS))
 		return -1;
 
-/*
+	/*
  * Set autorepeat to fastest possible.
  */
 
@@ -914,7 +937,6 @@ static void atkbd_cleanup(struct serio *serio)
 	atkbd_disable(atkbd);
 	ps2_command(&atkbd->ps2dev, NULL, ATKBD_CMD_RESET_DEF);
 }
-
 
 /*
  * atkbd_disconnect() closes and frees.
@@ -944,8 +966,8 @@ static void atkbd_disconnect(struct serio *serio)
 /*
  * generate release events for the keycodes given in data
  */
-static void atkbd_apply_forced_release_keylist(struct atkbd* atkbd,
-						const void *data)
+static void atkbd_apply_forced_release_keylist(struct atkbd *atkbd,
+					       const void *data)
 {
 	const unsigned int *keys = data;
 	unsigned int i;
@@ -967,9 +989,7 @@ static unsigned int atkbd_dell_laptop_forced_release_keys[] = {
  * Perform fixup for HP system that doesn't generate release
  * for its video switch
  */
-static unsigned int atkbd_hp_forced_release_keys[] = {
-	0x94, -1U
-};
+static unsigned int atkbd_hp_forced_release_keys[] = { 0x94, -1U };
 
 /*
  * Samsung NC10,NC20 with Fn+F? key release not working
@@ -995,17 +1015,14 @@ static unsigned int atkbd_amilo_xi3650_forced_release_keys[] = {
 /*
  * Soltech TA12 system with broken key release on volume keys and mute key
  */
-static unsigned int atkdb_soltech_ta12_forced_release_keys[] = {
-	0xa0, 0xae, 0xb0, -1U
-};
+static unsigned int atkdb_soltech_ta12_forced_release_keys[] = { 0xa0, 0xae,
+								 0xb0, -1U };
 
 /*
  * Many notebooks don't send key release event for volume up/down
  * keys, with key list below common among them
  */
-static unsigned int atkbd_volume_forced_release_keys[] = {
-	0xae, 0xb0, -1U
-};
+static unsigned int atkbd_volume_forced_release_keys[] = { 0xae, 0xb0, -1U };
 
 /*
  * OQO 01+ multimedia keys (64--66) generate e0 6x upon release whereas
@@ -1076,25 +1093,33 @@ static void atkbd_set_keycode_table(struct atkbd *atkbd)
 		for (i = 0; i < 128; i++) {
 			scancode = atkbd_unxlate_table[i];
 			atkbd->keycode[i] = atkbd_set2_keycode[scancode];
-			atkbd->keycode[i | 0x80] = atkbd_set2_keycode[scancode | 0x80];
+			atkbd->keycode[i | 0x80] =
+				atkbd_set2_keycode[scancode | 0x80];
 			if (atkbd->scroll)
-				for (j = 0; j < ARRAY_SIZE(atkbd_scroll_keys); j++)
-					if ((scancode | 0x80) == atkbd_scroll_keys[j].set2)
-						atkbd->keycode[i | 0x80] = atkbd_scroll_keys[j].keycode;
+				for (j = 0; j < ARRAY_SIZE(atkbd_scroll_keys);
+				     j++)
+					if ((scancode | 0x80) ==
+					    atkbd_scroll_keys[j].set2)
+						atkbd->keycode[i | 0x80] =
+							atkbd_scroll_keys[j]
+								.keycode;
 		}
 	} else if (atkbd->set == 3) {
-		memcpy(atkbd->keycode, atkbd_set3_keycode, sizeof(atkbd->keycode));
+		memcpy(atkbd->keycode, atkbd_set3_keycode,
+		       sizeof(atkbd->keycode));
 	} else {
-		memcpy(atkbd->keycode, atkbd_set2_keycode, sizeof(atkbd->keycode));
+		memcpy(atkbd->keycode, atkbd_set2_keycode,
+		       sizeof(atkbd->keycode));
 
 		if (atkbd->scroll)
 			for (i = 0; i < ARRAY_SIZE(atkbd_scroll_keys); i++) {
 				scancode = atkbd_scroll_keys[i].set2;
-				atkbd->keycode[scancode] = atkbd_scroll_keys[i].keycode;
-		}
+				atkbd->keycode[scancode] =
+					atkbd_scroll_keys[i].keycode;
+			}
 	}
 
-/*
+	/*
  * HANGEUL and HANJA keys do not send release events so we need to
  * generate such events ourselves
  */
@@ -1106,7 +1131,7 @@ static void atkbd_set_keycode_table(struct atkbd *atkbd)
 	atkbd->keycode[scancode] = KEY_HANJA;
 	__set_bit(scancode, atkbd->force_release_mask);
 
-/*
+	/*
  * Perform additional fixups
  */
 	if (atkbd_platform_fixup)
@@ -1130,8 +1155,8 @@ static void atkbd_set_device_attrs(struct atkbd *atkbd)
 			 "AT %s Set %d keyboard",
 			 atkbd->translated ? "Translated" : "Raw", atkbd->set);
 
-	snprintf(atkbd->phys, sizeof(atkbd->phys),
-		 "%s/input0", atkbd->ps2dev.serio->phys);
+	snprintf(atkbd->phys, sizeof(atkbd->phys), "%s/input0",
+		 atkbd->ps2dev.serio->phys);
 
 	input_dev->name = atkbd->name;
 	input_dev->phys = atkbd->phys;
@@ -1145,31 +1170,34 @@ static void atkbd_set_device_attrs(struct atkbd *atkbd)
 	input_set_drvdata(input_dev, atkbd);
 
 	input_dev->evbit[0] = BIT_MASK(EV_KEY) | BIT_MASK(EV_REP) |
-		BIT_MASK(EV_MSC);
+			      BIT_MASK(EV_MSC);
 
 	if (atkbd->write) {
 		input_dev->evbit[0] |= BIT_MASK(EV_LED);
 		input_dev->ledbit[0] = BIT_MASK(LED_NUML) |
-			BIT_MASK(LED_CAPSL) | BIT_MASK(LED_SCROLLL);
+				       BIT_MASK(LED_CAPSL) |
+				       BIT_MASK(LED_SCROLLL);
 	}
 
 	if (atkbd->extra)
 		input_dev->ledbit[0] |= BIT_MASK(LED_COMPOSE) |
-			BIT_MASK(LED_SUSPEND) | BIT_MASK(LED_SLEEP) |
-			BIT_MASK(LED_MUTE) | BIT_MASK(LED_MISC);
+					BIT_MASK(LED_SUSPEND) |
+					BIT_MASK(LED_SLEEP) |
+					BIT_MASK(LED_MUTE) | BIT_MASK(LED_MISC);
 
 	if (!atkbd->softrepeat) {
 		input_dev->rep[REP_DELAY] = 250;
 		input_dev->rep[REP_PERIOD] = 33;
 	}
 
-	input_dev->mscbit[0] = atkbd->softraw ? BIT_MASK(MSC_SCAN) :
-		BIT_MASK(MSC_RAW) | BIT_MASK(MSC_SCAN);
+	input_dev->mscbit[0] = atkbd->softraw ?
+				       BIT_MASK(MSC_SCAN) :
+				       BIT_MASK(MSC_RAW) | BIT_MASK(MSC_SCAN);
 
 	if (atkbd->scroll) {
 		input_dev->evbit[0] |= BIT_MASK(EV_REL);
 		input_dev->relbit[0] = BIT_MASK(REL_WHEEL) |
-			BIT_MASK(REL_HWHEEL);
+				       BIT_MASK(REL_HWHEEL);
 		__set_bit(BTN_MIDDLE, input_dev->keybit);
 	}
 
@@ -1231,7 +1259,6 @@ static int atkbd_connect(struct serio *serio, struct serio_driver *drv)
 	mutex_init(&atkbd->mutex);
 
 	switch (serio->id.type) {
-
 	case SERIO_8042_XL:
 		atkbd->translated = true;
 		fallthrough;
@@ -1256,7 +1283,6 @@ static int atkbd_connect(struct serio *serio, struct serio_driver *drv)
 		goto fail2;
 
 	if (atkbd->write) {
-
 		if (atkbd_probe(atkbd)) {
 			err = -ENODEV;
 			goto fail3;
@@ -1285,9 +1311,12 @@ static int atkbd_connect(struct serio *serio, struct serio_driver *drv)
 
 	return 0;
 
- fail3:	serio_close(serio);
- fail2:	serio_set_drvdata(serio, NULL);
- fail1:	input_free_device(dev);
+fail3:
+	serio_close(serio);
+fail2:
+	serio_set_drvdata(serio, NULL);
+fail1:
+	input_free_device(dev);
 	kfree(atkbd);
 	return err;
 }
@@ -1317,7 +1346,8 @@ static int atkbd_reconnect(struct serio *serio)
 		if (atkbd_probe(atkbd))
 			goto out;
 
-		if (atkbd->set != atkbd_select_set(atkbd, atkbd->set, atkbd->extra))
+		if (atkbd->set !=
+		    atkbd_select_set(atkbd, atkbd->set, atkbd->extra))
 			goto out;
 
 		/*
@@ -1330,7 +1360,6 @@ static int atkbd_reconnect(struct serio *serio)
 		atkbd_set_leds(atkbd);
 		if (!atkbd->softrepeat)
 			atkbd_set_repeat_rate(atkbd);
-
 	}
 
 	/*
@@ -1346,29 +1375,29 @@ static int atkbd_reconnect(struct serio *serio)
 
 	retval = 0;
 
- out:
+out:
 	mutex_unlock(&atkbd->mutex);
 	return retval;
 }
 
 static const struct serio_device_id atkbd_serio_ids[] = {
 	{
-		.type	= SERIO_8042,
-		.proto	= SERIO_ANY,
-		.id	= SERIO_ANY,
-		.extra	= SERIO_ANY,
+		.type = SERIO_8042,
+		.proto = SERIO_ANY,
+		.id = SERIO_ANY,
+		.extra = SERIO_ANY,
 	},
 	{
-		.type	= SERIO_8042_XL,
-		.proto	= SERIO_ANY,
-		.id	= SERIO_ANY,
-		.extra	= SERIO_ANY,
+		.type = SERIO_8042_XL,
+		.proto = SERIO_ANY,
+		.id = SERIO_ANY,
+		.extra = SERIO_ANY,
 	},
 	{
-		.type	= SERIO_RS232,
-		.proto	= SERIO_PS2SER,
-		.id	= SERIO_ANY,
-		.extra	= SERIO_ANY,
+		.type = SERIO_RS232,
+		.proto = SERIO_PS2SER,
+		.id = SERIO_ANY,
+		.extra = SERIO_ANY,
 	},
 	{ 0 }
 };
@@ -1390,7 +1419,8 @@ static struct serio_driver atkbd_drv = {
 };
 
 static ssize_t atkbd_attr_show_helper(struct device *dev, char *buf,
-				ssize_t (*handler)(struct atkbd *, char *))
+				      ssize_t (*handler)(struct atkbd *,
+							 char *))
 {
 	struct serio *serio = to_serio_port(dev);
 	struct atkbd *atkbd = serio_get_drvdata(serio);
@@ -1398,8 +1428,9 @@ static ssize_t atkbd_attr_show_helper(struct device *dev, char *buf,
 	return handler(atkbd, buf);
 }
 
-static ssize_t atkbd_attr_set_helper(struct device *dev, const char *buf, size_t count,
-				ssize_t (*handler)(struct atkbd *, const char *, size_t))
+static ssize_t
+atkbd_attr_set_helper(struct device *dev, const char *buf, size_t count,
+		      ssize_t (*handler)(struct atkbd *, const char *, size_t))
 {
 	struct serio *serio = to_serio_port(dev);
 	struct atkbd *atkbd = serio_get_drvdata(serio);
@@ -1423,7 +1454,8 @@ static ssize_t atkbd_show_extra(struct atkbd *atkbd, char *buf)
 	return sprintf(buf, "%d\n", atkbd->extra ? 1 : 0);
 }
 
-static ssize_t atkbd_set_extra(struct atkbd *atkbd, const char *buf, size_t count)
+static ssize_t atkbd_set_extra(struct atkbd *atkbd, const char *buf,
+			       size_t count)
 {
 	struct input_dev *old_dev, *new_dev;
 	unsigned int value;
@@ -1467,22 +1499,22 @@ static ssize_t atkbd_set_extra(struct atkbd *atkbd, const char *buf, size_t coun
 			input_free_device(new_dev);
 
 			atkbd->dev = old_dev;
-			atkbd->set = atkbd_select_set(atkbd, old_set, old_extra);
+			atkbd->set =
+				atkbd_select_set(atkbd, old_set, old_extra);
 			atkbd_set_keycode_table(atkbd);
 			atkbd_set_device_attrs(atkbd);
 
 			return err;
 		}
 		input_unregister_device(old_dev);
-
 	}
 	return count;
 }
 
 static ssize_t atkbd_show_force_release(struct atkbd *atkbd, char *buf)
 {
-	size_t len = scnprintf(buf, PAGE_SIZE - 1, "%*pbl",
-			       ATKBD_KEYMAP_SIZE, atkbd->force_release_mask);
+	size_t len = scnprintf(buf, PAGE_SIZE - 1, "%*pbl", ATKBD_KEYMAP_SIZE,
+			       atkbd->force_release_mask);
 
 	buf[len++] = '\n';
 	buf[len] = '\0';
@@ -1490,8 +1522,8 @@ static ssize_t atkbd_show_force_release(struct atkbd *atkbd, char *buf)
 	return len;
 }
 
-static ssize_t atkbd_set_force_release(struct atkbd *atkbd,
-					const char *buf, size_t count)
+static ssize_t atkbd_set_force_release(struct atkbd *atkbd, const char *buf,
+				       size_t count)
 {
 	/* 64 bytes on stack should be acceptable */
 	DECLARE_BITMAP(new_mask, ATKBD_KEYMAP_SIZE);
@@ -1501,17 +1533,18 @@ static ssize_t atkbd_set_force_release(struct atkbd *atkbd,
 	if (err)
 		return err;
 
-	memcpy(atkbd->force_release_mask, new_mask, sizeof(atkbd->force_release_mask));
+	memcpy(atkbd->force_release_mask, new_mask,
+	       sizeof(atkbd->force_release_mask));
 	return count;
 }
-
 
 static ssize_t atkbd_show_scroll(struct atkbd *atkbd, char *buf)
 {
 	return sprintf(buf, "%d\n", atkbd->scroll ? 1 : 0);
 }
 
-static ssize_t atkbd_set_scroll(struct atkbd *atkbd, const char *buf, size_t count)
+static ssize_t atkbd_set_scroll(struct atkbd *atkbd, const char *buf,
+				size_t count)
 {
 	struct input_dev *old_dev, *new_dev;
 	unsigned int value;
@@ -1598,7 +1631,8 @@ static ssize_t atkbd_set_set(struct atkbd *atkbd, const char *buf, size_t count)
 			input_free_device(new_dev);
 
 			atkbd->dev = old_dev;
-			atkbd->set = atkbd_select_set(atkbd, old_set, old_extra);
+			atkbd->set =
+				atkbd_select_set(atkbd, old_set, old_extra);
 			atkbd_set_keycode_table(atkbd);
 			atkbd_set_device_attrs(atkbd);
 
@@ -1614,7 +1648,8 @@ static ssize_t atkbd_show_softrepeat(struct atkbd *atkbd, char *buf)
 	return sprintf(buf, "%d\n", atkbd->softrepeat ? 1 : 0);
 }
 
-static ssize_t atkbd_set_softrepeat(struct atkbd *atkbd, const char *buf, size_t count)
+static ssize_t atkbd_set_softrepeat(struct atkbd *atkbd, const char *buf,
+				    size_t count)
 {
 	struct input_dev *old_dev, *new_dev;
 	unsigned int value;
@@ -1662,13 +1697,13 @@ static ssize_t atkbd_set_softrepeat(struct atkbd *atkbd, const char *buf, size_t
 	return count;
 }
 
-
 static ssize_t atkbd_show_softraw(struct atkbd *atkbd, char *buf)
 {
 	return sprintf(buf, "%d\n", atkbd->softraw ? 1 : 0);
 }
 
-static ssize_t atkbd_set_softraw(struct atkbd *atkbd, const char *buf, size_t count)
+static ssize_t atkbd_set_softraw(struct atkbd *atkbd, const char *buf,
+				 size_t count)
 {
 	struct input_dev *old_dev, *new_dev;
 	unsigned int value;

--- a/drivers/input/keyboard/atkbd.c
+++ b/drivers/input/keyboard/atkbd.c
@@ -1225,7 +1225,7 @@ static int atkbd_connect(struct serio *serio, struct serio_driver *drv)
 	atkbd->dev = dev;
 	ret = ps2_init(&atkbd->ps2dev, serio);
 	if (ret) {
-		dev_err(&serio->dev, "Failed to initialize PS/2 protocol.\n");
+		dev_err(&serio->dev, "Failed to initialize PS/2.\n");
 		goto fail1;
 	}
 	INIT_DELAYED_WORK(&atkbd->event_work, atkbd_event_work);

--- a/drivers/input/keyboard/atkbd.c
+++ b/drivers/input/keyboard/atkbd.c
@@ -26,7 +26,6 @@
 #include <linux/mutex.h>
 #include <linux/dmi.h>
 #include <linux/property.h>
-#include <linux/printk.h>
 
 #define DRIVER_DESC	"AT and PS/2 keyboard driver"
 

--- a/drivers/input/serio/libps2.c
+++ b/drivers/input/serio/libps2.c
@@ -376,15 +376,24 @@ EXPORT_SYMBOL(ps2_sliced_command);
  * ps2_init() initializes ps2dev structure
  */
 
-void ps2_init(struct ps2dev *ps2dev, struct serio *serio)
+int ps2_init(struct ps2dev *ps2dev, struct serio *serio)
 {
-	mutex_init(&ps2dev->cmd_mutex);
-	lockdep_set_subclass(&ps2dev->cmd_mutex, serio->depth);
-	init_waitqueue_head(&ps2dev->wait);
-	ps2dev->serio = serio;
+    int ret = 0;
+    if (!ps2dev || !serio) {
+        ret = -EINVAL;
+        goto out;
+    }
+
+    mutex_init(&ps2dev->cmd_mutex);
+    lockdep_set_subclass(&ps2dev->cmd_mutex, serio->depth);
+    init_waitqueue_head(&ps2dev->wait);
+    ps2dev->serio = serio;
+	goto out;
+
+out:
+    return ret;
 }
 EXPORT_SYMBOL(ps2_init);
-
 /*
  * ps2_handle_ack() is supposed to be used in interrupt handler
  * to properly process ACK/NAK of a command from a PS/2 device.

--- a/include/linux/libps2.h
+++ b/include/linux/libps2.h
@@ -45,7 +45,7 @@ struct ps2dev {
 	u8 nak;
 };
 
-void ps2_init(struct ps2dev *ps2dev, struct serio *serio);
+int ps2_init(struct ps2dev *ps2dev, struct serio *serio);
 int ps2_sendbyte(struct ps2dev *ps2dev, u8 byte, unsigned int timeout);
 void ps2_drain(struct ps2dev *ps2dev, size_t maxbytes, unsigned int timeout);
 void ps2_begin_command(struct ps2dev *ps2dev);


### PR DESCRIPTION
In this patch:
### Added error handling for ps2 init
In the function atkbd_connect() we call ps2_init() which can fail if
some arguments are not entered correctly. This patch adds error
handeling for this function. and will stop atkbd from loading if the
ps2_init() function fails.

#### Formatted file
A quick tidy up has been done to this file