### PR TITLE
initramfs: several improvements to module

### DIFF
--- a/init/initramfs.c
+++ b/init/initramfs.c
@@ -25,6 +25,7 @@
 #include <linux/init_syscalls.h>
 #include <linux/task_work.h>
 #include <linux/umh.h>
+#include <linux/printk.h>
 
 static __initdata bool csum_present;
 static __initdata u32 io_csum;
@@ -167,7 +168,7 @@ static char __init *find_link(int major, int minor, int ino,
 /**
  * free_hash - Free the initramfs hash table.
 */
-static void __init free_hash(void)
+static int __init free_hash(void)
 {
 	struct hash **p, *q;
 	for (p = head; p < head + 32; p++) {
@@ -177,6 +178,11 @@ static void __init free_hash(void)
 			kfree(q);
 		}
 	}
+	if (head[0] || head[1] || head[2] || head[3]) {
+		pr_warn("initramfs: Failed to free all data in the hash table\n");
+		return -1;
+	}
+	return 0;
 }
 
 #ifdef CONFIG_INITRAMFS_PRESERVE_MTIME


### PR DESCRIPTION
Adds comments to the `initramfs.c` functions to explain what they do and how they work. This is to help anyone who wants to understand the code and/or make changes to it.

The function `free_hash()` in `initramfs.c` is responsible for freeing the initramfs hash table. However, in certain scenarios, the function may not be able to free all the data in the hash table as expected.

To alert the user about this situation, we have added a `pr_warn` statement inside the `free_hash()` function.

This warning message will be printed in case the hash table still contains data after the function completes its execution, which might indicate a potential issue with memory management in the initramfs module. By adding this warning, this can help provide valuable information to users and developers to investigate and resolve any memory-related  problems related to the hash table in the initramfs code.