### PR TITLE
printk_clear_debug: Add a macro

### DIFF
--- a/include/linux/printk_clear_debug.h
+++ b/include/linux/printk_clear_debug.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/**
+ * printk_clear_debug.h - print a kernel debugging message that is
+ * easy to spot and clear in the log
+ * 
+ * By: Lewis Evans
+ * Date: 2023/08/07
+*/
+
+#ifndef _LINUX_PRINTK_CLEAR_DEBUG_H
+#define _LINUX_PRINTK_CLEAR_DEBUG_H
+
+
+#include <linux/printk.h>
+
+#ifdef CONFIG_PRINTK_CLEAR_DEBUG
+/**
+ * printk_clear_debug() - print a kernel debugging message that is
+ * clear and easy to spot in the log. This is useful for debugging
+ * when there are lots of other messages in the log. It will also
+ * show up in the log even when the debug level is turned off.
+ * 
+ * To show or hide these messages that may have been left in the code
+ * set in the kernel config: CONFIG_PRINTK_CLEAR_DEBUG
+ * 
+*/
+#define printk_clear_debug(fmt, ...) \
+    printk("====================[ DEBUG ]====================\n" \
+        fmt "\n" \
+        "==================[ END DEBUG ]==================\n", \
+        ##__VA_ARGS__)
+
+#else
+/**
+ * If we dont want to show these messages, then just define the macro
+ * to do nothing. Then the user wont see the messages in the log.
+*/
+#define printk_clear_debug(fmt, ...) do {} while (0)
+#endif /* CONFIG_PRINTK_CLEAR_DEBUG */
+#endif /* _LINUX_PRINTK_DEBUG_H */

--- a/init/Kconfig
+++ b/init/Kconfig
@@ -1979,3 +1979,10 @@ config ARCH_HAS_SYNC_CORE_BEFORE_USERMODE
 # <asm/syscall_wrapper.h>.
 config ARCH_HAS_SYSCALL_WRAPPER
 	def_bool n
+
+config PRINTK_CLEAR_DEBUG
+	bool "Enable printk clear debug messages"
+	help
+	  Enable printk clear debug messages. Turn this off if you don't 
+	  want to see these messages in the log.
+	default n


### PR DESCRIPTION
This commit introduces the `printk_clear_debug` macro, which facilitates the printing of kernel debugging messages in a clear and easily identifiable format in the log. This macro is designed to aid debugging in situations with a high volume of log messages, making it simpler to identify relevant debugging output.

The `printk_clear_debug()` macro includes special formatting to enclose the debug message within `[ DEBUG ]` markers, making it more prominent in the log. Additionally, the macro can display messages in the log even when the debug level is turned off, providing valuable debugging information regardless of the current log level settings.

Furthermore, the macro is configurable based on the kernel configuration option `CONFIG_PRINTK_CLEAR_DEBUG`. If this option is enabled, the `printk_clear_debug` macro will be active and display the debugging messages. On the other hand, if the option is disabled, the macro will be defined as an empty statement, preventing the messages from showing up in the log.

This change enables developers to selectively control the visibility of the debugging messages by configuring the `CONFIG_PRINTK_CLEAR_DEBUG` option during the kernel build process.

## Example:

```c
printk_clear_debug("test") // No need for a new line
```

## Output:
```
[    0.000000] ====================[ DEBUG ]====================
[    0.000000] test
[    0.000000] ==================[ END DEBUG ]==================
```