### PR TITLE
panic: add start panic identifier message

### DIFF
--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -331,7 +331,7 @@ void panic(const char *fmt, ...)
 	if (len && buf[len - 1] == '\n')
 		buf[len - 1] = '\0';
 
-	pr_emerg("Kernel panic - not syncing: %s\n", buf);
+	pr_emerg("---[ start kernel panic - not syncing: %s ]---\n", buf);
 #ifdef CONFIG_DEBUG_BUGVERBOSE
 	/*
 	 * Avoid nested stack-dumping if a panic occurs during oops processing


### PR DESCRIPTION
This commit adds a message to the start of the panic function to make it easier to identify where the panic starts in the log.

Signed-off-by: lewisevans2007 <60709927+lewisevans2007@users.noreply.github.com>