### PR TITLE
PCI: Debugging statements pci_enable_device

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -32,6 +32,7 @@
 #include <asm/dma.h>
 #include <linux/aer.h>
 #include <linux/bitfield.h>
+#include <linux/printk.h>
 #include "pci.h"
 
 DEFINE_MUTEX(pci_slot_mutex);
@@ -2089,9 +2090,22 @@ EXPORT_SYMBOL(pci_enable_device_mem);
  * Note we don't actually enable the device many times if we call
  * this function repeatedly (we just increment the count).
  */
+
 int pci_enable_device(struct pci_dev *dev)
 {
-	return pci_enable_device_flags(dev, IORESOURCE_MEM | IORESOURCE_IO);
+	printk(KERN_INFO "pci_enable_device: %s\n", pci_name(dev));
+	printk(KERN_INFO "pci_enable_device: dev->vendor: %x\n", dev->vendor);
+	printk(KERN_INFO "pci_enable_device: dev->device: %x\n", dev->device);
+	printk(KERN_INFO "pci_enable_device: dev->subsystem_vendor: %x\n", dev->subsystem_vendor);
+	printk(KERN_INFO "pci_enable_device: dev->subsystem_device: %x\n", dev->subsystem_device);
+	printk(KERN_INFO "pci_enable_device: dev->class: %x\n", dev->class);
+	printk(KERN_INFO "pci_enable_device: dev->revision: %x\n", dev->revision);
+	printk(KERN_INFO "pci_enable_device: dev->hdr_type: %x\n", dev->hdr_type);
+	printk(KERN_INFO "pci_enable_device: dev->pcie_cap: %x\n", dev->pcie_cap);
+	int ret;
+	ret = pci_enable_device_flags(dev, IORESOURCE_MEM | IORESOURCE_IO);
+	printk(KERN_INFO "pci_enable_device: return code: %x\n", ret);
+	return ret;
 }
 EXPORT_SYMBOL(pci_enable_device);
 


### PR DESCRIPTION
Added debugging statements to `pci_enable_device()`.

This function will now make a output like this:
```
[    0.249622] pci_enable_device: 0000:00:01.0
[    0.249720] pci_enable_device: dev->vendor: 8086
[    0.249811] pci_enable_device: dev->device: 24cd
[    0.249896] pci_enable_device: dev->subsystem_vendor: 1af4
[    0.249985] pci_enable_device: dev->subsystem_device: 1100
[    0.250078] pci_enable_device: dev->class: c0320
[    0.250147] pci_enable_device: dev->revision: 10
[    0.250213] pci_enable_device: dev->hdr_type: 0
[    0.250281] pci_enable_device: dev->pcie_cap: 
```

**Note:** This function in the future will have kconfig support