### PR TITLE
PCI: Add debugging config

### DIFF
--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -2090,7 +2090,7 @@ EXPORT_SYMBOL(pci_enable_device_mem);
  * Note we don't actually enable the device many times if we call
  * this function repeatedly (we just increment the count).
  */
-
+#ifdef CONFIG_PCI_DEBUG
 int pci_enable_device(struct pci_dev *dev)
 {
 	printk(KERN_INFO "pci_enable_device: %s\n", pci_name(dev));
@@ -2108,6 +2108,13 @@ int pci_enable_device(struct pci_dev *dev)
 	return ret;
 }
 EXPORT_SYMBOL(pci_enable_device);
+#else
+int pci_enable_device(struct pci_dev *dev)
+{
+	return pci_enable_device_flags(dev, IORESOURCE_MEM | IORESOURCE_IO);
+}
+EXPORT_SYMBOL(pci_enable_device);
+#endif
 
 /*
  * Managed PCI resources.  This manages device on/off, INTx/MSI/MSI-X

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -11,13 +11,7 @@ menu "Library routines"
 config RAID6_PQ
 	tristate
 
-config RAID6_PQ_BENCHMARK
-	bool "Automatically choose fastest RAID6 PQ functions"
-	depends on RAID6_PQ
-	default y
-	help
-	  Benchmark all available RAID6 PQ functions on init and choose the
-	  fastest one.
+
 
 config LINEAR_RANGES
 	tristate


### PR DESCRIPTION
Patches issues raised in #6 and #7.

To enable debugging features on `pci_enable_device()` turn on `PCI_DEBUG`