### PR TITLE
Kconfig: add accidentally removed options to Kconfig

### DIFF
--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -11,7 +11,13 @@ menu "Library routines"
 config RAID6_PQ
 	tristate
 
-
+config RAID6_PQ_BENCHMARK
+	bool "Automatically choose fastest RAID6 PQ functions"
+	depends on RAID6_PQ
+	default y
+	help
+	  Benchmark all available RAID6 PQ functions on init and choose the
+	  fastest one.
 
 config LINEAR_RANGES
 	tristate


### PR DESCRIPTION
Add back removed Kconfig that was accidentally removed in 63ddd064b2e7d33ebbbab6abeff7e16dd64150cd and #8 