### PR TITLE
Virtio: add debug config option

### DIFF
--- a/drivers/virtio/Kconfig
+++ b/drivers/virtio/Kconfig
@@ -173,4 +173,13 @@ config VIRTIO_DMA_SHARED_BUFFER
 	 This option adds a flavor of dma buffers that are backed by
 	 virtio resources.
 
+config VIRTIO_DEBUG_PRINTS
+	bool "Enable debug prints for virtio"
+	depends on DEBUG_KERNEL
+	default n
+	help
+	  This option enables debug prints for virtio. Usefull to see if virtio is being enabled or not.
+
+	  If unsure, say N.
+
 endif # VIRTIO_MENU

--- a/drivers/virtio/virtio.c
+++ b/drivers/virtio/virtio.c
@@ -553,6 +553,8 @@ err:
 EXPORT_SYMBOL_GPL(virtio_device_restore);
 #endif
 
+
+#ifdef CONFIG_VIRTIO_DEBUG_PRINTS
 static int virtio_init(void)
 {
 	printk(KERN_INFO "virtio: initializing\n");
@@ -562,6 +564,7 @@ static int virtio_init(void)
 	return 0;
 }
 
+
 static void __exit virtio_exit(void)
 {
 	printk(KERN_INFO "virtio: exit\n");
@@ -569,6 +572,21 @@ static void __exit virtio_exit(void)
 	ida_destroy(&virtio_index_ida);
 	printk(KERN_INFO "virtio: exit done\n");
 }
+#else
+static int __init virtio_init(void)
+{
+	if (bus_register(&virtio_bus) != 0)
+		panic("virtio bus registration failed");
+	return 0;
+}
+
+static void __exit virtio_exit(void)
+{
+	bus_unregister(&virtio_bus);
+	ida_destroy(&virtio_index_ida);
+}
+#endif
+
 core_initcall(virtio_init);
 module_exit(virtio_exit);
 


### PR DESCRIPTION
Added debug config option in Kconfig

Located at:
```
 -> Device Drivers
    -> Virtio drivers (VIRTIO_MENU [=y]) 
        -> Enable debug prints for virtio (VIRTIO_DEBUG_PRINTS [=n]) 
```