### PR TITLE
Panic: shutdown on panic

### DIFF
--- a/arch/arm64/kernel/asm-offsets.s
+++ b/arch/arm64/kernel/asm-offsets.s
@@ -56,27 +56,27 @@ main:
 // arch/arm64/kernel/asm-offsets.c:48:   DEFINE(THREAD_CPU_CONTEXT,	offsetof(struct task_struct, thread.cpu_context));
 // 48 "arch/arm64/kernel/asm-offsets.c" 1
 	
-.ascii "->THREAD_CPU_CONTEXT 2656 offsetof(struct task_struct, thread.cpu_context)"	//
+.ascii "->THREAD_CPU_CONTEXT 2560 offsetof(struct task_struct, thread.cpu_context)"	//
 // 0 "" 2
 // arch/arm64/kernel/asm-offsets.c:49:   DEFINE(THREAD_SCTLR_USER,	offsetof(struct task_struct, thread.sctlr_user));
 // 49 "arch/arm64/kernel/asm-offsets.c" 1
 	
-.ascii "->THREAD_SCTLR_USER 3744 offsetof(struct task_struct, thread.sctlr_user)"	//
+.ascii "->THREAD_SCTLR_USER 3648 offsetof(struct task_struct, thread.sctlr_user)"	//
 // 0 "" 2
 // arch/arm64/kernel/asm-offsets.c:51:   DEFINE(THREAD_KEYS_USER,	offsetof(struct task_struct, thread.keys_user));
 // 51 "arch/arm64/kernel/asm-offsets.c" 1
 	
-.ascii "->THREAD_KEYS_USER 3640 offsetof(struct task_struct, thread.keys_user)"	//
+.ascii "->THREAD_KEYS_USER 3544 offsetof(struct task_struct, thread.keys_user)"	//
 // 0 "" 2
 // arch/arm64/kernel/asm-offsets.c:54:   DEFINE(THREAD_KEYS_KERNEL,	offsetof(struct task_struct, thread.keys_kernel));
 // 54 "arch/arm64/kernel/asm-offsets.c" 1
 	
-.ascii "->THREAD_KEYS_KERNEL 3720 offsetof(struct task_struct, thread.keys_kernel)"	//
+.ascii "->THREAD_KEYS_KERNEL 3624 offsetof(struct task_struct, thread.keys_kernel)"	//
 // 0 "" 2
 // arch/arm64/kernel/asm-offsets.c:57:   DEFINE(THREAD_MTE_CTRL,	offsetof(struct task_struct, thread.mte_ctrl));
 // 57 "arch/arm64/kernel/asm-offsets.c" 1
 	
-.ascii "->THREAD_MTE_CTRL 3736 offsetof(struct task_struct, thread.mte_ctrl)"	//
+.ascii "->THREAD_MTE_CTRL 3640 offsetof(struct task_struct, thread.mte_ctrl)"	//
 // 0 "" 2
 // arch/arm64/kernel/asm-offsets.c:59:   BLANK();
 // 59 "arch/arm64/kernel/asm-offsets.c" 1

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -450,6 +450,31 @@ void panic(const char *fmt, ...)
 			 "twice on console to return to the boot prom\n");
 	}
 #endif
+#ifdef CONFIG_SHUTDOWN_ON_PANIC
+	/* About this section:
+	 * This code is only useful for kernel testers or devices 
+	 * that need to be shut down when a kernel panic is triggered.
+	 * 
+	 * This function ca be turned on by setting CONFIG_SHUTDOWN_ON_PANIC
+	 * on the Kconfig file. at Kernel hacking -> Panic options -> Halt machine on panic
+	 * 
+	 * Reason? When a system is panicked it sit at 100% CPU usage which can 
+	 * cause overheating on some systems and a tester can leave QEMU running 
+	 * with a panicked kernel and not realize why their system is running slow or hot. 
+	 * This prevents the issue from happening. 
+	 * 
+	 * Just running a panicked system for 10 minutes in QEMU on a macbook pro caused 
+	 * the CPU to reach 60ºC from 30ºC on a M3 Pro Processor.
+	*/
+
+	pr_emerg("---[ end Kernel panic - not syncing: %s ]---\n", buf);
+
+	/* For reference in logs so we know why the system was shutdown */
+	pr_emerg("System powering down due to kernel panic");
+
+	/* Shutdown the system */
+	kernel_power_off();
+#endif
 #if defined(CONFIG_S390)
 	disabled_wait();
 #endif

--- a/lib/Kconfig.debug
+++ b/lib/Kconfig.debug
@@ -8,6 +8,14 @@ config FANCY_PANIC
 	  If you say Y here, the kernel will display a nice
 	  start kernel panic message.
 
+
+config SHUTDOWN_ON_PANIC
+	bool "Halt machine on panic"
+	help
+	  If you say Y here, the machine will immediately halt when
+	  the kernel panics.  This is useful if debugging panics on qemu
+	  with no graphical console since when a machine is panicked it
+	  uses 100% CPU and qemu will not respond to keyboard input.
 endmenu
 
 menu "printk and dmesg options"


### PR DESCRIPTION
Added a new config option to shutdown the system on panic. This is useful for testers and some systems becuse when the system panics it sits at a high CPU usage and can cause the system to overheat and run slow.

The kernel panic message is as follows:
```
[    0.193962] ---[ end Kernel panic - not syncing: System is deadlocked on memory ]---
[    0.194112] System powering down due to kernel panic
[    0.194966] reboot: Power down
```

The panic will run `kernel_power_off()` which should cleanly shutdown.