### PR TITLE
Add printk to notify when no args have been sent to init

### DIFF
--- a/init/main.c
+++ b/init/main.c
@@ -935,13 +935,20 @@ asmlinkage __visible __init __no_sanitize_address __noreturn
 				  __stop___param - __start___param, -1, -1,
 				  NULL, &unknown_bootoption);
 	print_unknown_bootoptions();
-	if (!IS_ERR_OR_NULL(after_dashes))
+	bool extra_args_been_passed = false;
+	if (!IS_ERR_OR_NULL(after_dashes)){
 		parse_args("Setting init args", after_dashes, NULL, 0, -1, -1,
 			   NULL, set_init_arg);
-	if (extra_init_args)
+		extra_args_been_passed = true;
+	}
+	if (extra_init_args) {
 		parse_args("Setting extra init args", extra_init_args, NULL, 0,
 			   -1, -1, NULL, set_init_arg);
-
+		extra_args_been_passed = true;
+	}
+	if (extra_args_been_passed == false) {
+		pr_notice("No extra init args have been passed\n");
+	}
 	/* Architectural and non-timekeeping rng init, before allocator init */
 	random_init_early(command_line);
 

--- a/init/main.c
+++ b/init/main.c
@@ -935,6 +935,8 @@ asmlinkage __visible __init __no_sanitize_address __noreturn
 				  __stop___param - __start___param, -1, -1,
 				  NULL, &unknown_bootoption);
 	print_unknown_bootoptions();
+
+	/* INIT arguments */
 	bool extra_args_been_passed = false;
 	if (!IS_ERR_OR_NULL(after_dashes)){
 		parse_args("Setting init args", after_dashes, NULL, 0, -1, -1,
@@ -949,6 +951,7 @@ asmlinkage __visible __init __no_sanitize_address __noreturn
 	if (extra_args_been_passed == false) {
 		pr_notice("No extra init args have been passed\n");
 	}
+	
 	/* Architectural and non-timekeeping rng init, before allocator init */
 	random_init_early(command_line);
 


### PR DESCRIPTION
This pull request adds a printk statement to notify when no extra init args have been passed to the init function.